### PR TITLE
meta-mender-toradex-nxp: add kas configurations

### DIFF
--- a/kas/colibri-imx8x.yml
+++ b/kas/colibri-imx8x.yml
@@ -1,0 +1,19 @@
+header:
+  version: 14
+  includes:
+  - kas/include/mender-full.yml
+  - kas/include/toradex-nxp.yml
+
+machine: colibri-imx8x
+
+target: core-image-minimal
+
+local_conf_header:
+  colibri-imx8x: |
+    # Settings for colibri-imx8x
+    MENDER_IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET:colibri-imx8x = "0"
+    MENDER_BOOT_PART_SIZE_MB:colibri-imx8x = "32"
+    OFFSET_SPL_PAYLOAD:colibri-imx8x = ""
+    MENDER_STORAGE_DEVICE:colibri-imx8x = "/dev/mmcblk0"
+    MENDER_STORAGE_TOTAL_SIZE_MB:colibri-imx8x = "2048"
+    KERNEL_DEVICETREE:colibri-imx8x = "freescale/imx8qxp-colibri-iris-v2.dtb"

--- a/kas/include/toradex-nxp.yml
+++ b/kas/include/toradex-nxp.yml
@@ -1,0 +1,51 @@
+header:
+  version: 14
+  includes:
+  - kas/include/nxp.yml
+
+repos:
+  meta-toradex-bsp-common:
+    url: https://git.toradex.com/meta-toradex-bsp-common.git
+    commit: 95c85e1a570732a4680a5b7a720bb691741b78b7
+    # branch: scarthgap-7.x.y
+
+  meta-toradex-nxp:
+    url: https://git.toradex.com/meta-toradex-nxp.git
+    commit: 5f9acd5758ba0fa1a3c27c0a96503c0bef533d99
+    # branch: scarthgap-7.x.y
+
+  meta-mender-community:
+    layers:
+      meta-mender-toradex-nxp:
+
+local_conf_header:
+  toradex-nxp: |
+    INHERIT += "mender-toradex"
+    
+    # Comment/remove below to enable GRUB integration instead of U-Boot
+    MENDER_FEATURES_ENABLE:append = " mender-uboot mender-image-sd"
+    MENDER_FEATURES_DISABLE:append = " mender-grub mender-image-uefi"
+    
+    IMAGE_CLASSES += "image_type_mender_tezi"
+    IMAGE_FSTYPES:append = " mender_tezi"
+    IMAGE_FSTYPES:remove = " teziimg"
+    
+    # Default is Image.gz, which is not compatible with GRUB
+    KERNEL_IMAGETYPE:aarch64:mender-grub = "Image"
+    
+    # boot.scr conflicts when using GRUB
+    IMAGE_BOOT_FILES:remove:mender-grub = "boot.scr-verdin-imx8mm;boot.scr"
+    
+    # Remove files from boot partition that are loaded by Mender
+    # from the root partitions; this allows the files to be updated OTA
+    IMAGE_BOOT_FILES:remove:mender-uboot = "zImage ${KERNEL_DEVICETREE} overlays.txt overlays/*;overlays/"
+    
+    # Append the Mender provided bootargs to tdxargs
+    # the Toradex boot.scr will overwrite bootargs so we stash the context in tdxargs
+    MENDER_UBOOT_POST_SETUP_COMMANDS:append = " ; setenv tdxargs \${tdxargs} \${bootargs}; "
+    
+    # Make sure the Toradex boot script finds the overlays and overlays.txt file in
+    # the /boot directory of the rootfs partition
+    MENDER_UBOOT_POST_SETUP_COMMANDS:append = " ; setenv overlays_file /boot/overlays.txt ; setenv overlays_prefix boot/overlays/ "
+    
+    TORADEX_BSP_VERSION = "toradex-bsp-7.1.0"

--- a/kas/verdin-imx8mm.yml
+++ b/kas/verdin-imx8mm.yml
@@ -1,0 +1,16 @@
+header:
+  version: 14
+  includes:
+  - kas/include/mender-full.yml
+  - kas/include/toradex-nxp.yml
+
+machine: verdin-imx8mm
+
+target: core-image-minimal
+
+local_conf_header:
+  verdin-imx8mm: |
+    # Settings for verdin-imx8mm
+    MENDER_BOOT_PART_SIZE_MB:verdin-imx8mm = "32"
+    OFFSET_SPL_PAYLOAD:verdin-imx8mm = ""
+    KERNEL_DEVICETREE:verdin-imx8mm = "freescale/imx8mm-verdin-wifi-dahlia.dtb"

--- a/kas/verdin-imx8mp.yml
+++ b/kas/verdin-imx8mp.yml
@@ -1,0 +1,21 @@
+header:
+  version: 14
+  includes:
+  - kas/include/mender-full.yml
+  - kas/include/toradex-nxp.yml
+
+machine: verdin-imx8mp
+
+target: core-image-minimal
+
+local_conf_header:
+  verdin-imx8mp: |
+    # Settings for verdin-imx8mp
+    MENDER_BOOT_PART_SIZE_MB:verdin-imx8mp = "32"
+    OFFSET_SPL_PAYLOAD:verdin-imx8mp = ""
+    MENDER_IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET:verdin-imx8mp = "0"
+    MENDER_UBOOT_STORAGE_INTERFACE:verdin-imx8mp = "mmc"
+    MENDER_UBOOT_STORAGE_DEVICE:verdin-imx8mp = "2"
+    MENDER_STORAGE_DEVICE:verdin-imx8mp = "/dev/mmcblk2"
+    MENDER_STORAGE_TOTAL_SIZE_MB:verdin-imx8mp = "2048"
+    KERNEL_DEVICETREE:verdin-imx8mp = "freescale/imx8mp-verdin-wifi-dahlia.dtb"

--- a/meta-mender-toradex-nxp/README.md
+++ b/meta-mender-toradex-nxp/README.md
@@ -2,7 +2,7 @@
 
 Mender integration layer for Toradex family of boards.
 
-So far the iamges build for:
+The supported and tested boards are:
 
 - Toradex Verdin iMX8M Mini
 - Toradex Verdin iMX8M Plus
@@ -11,6 +11,12 @@ So far the iamges build for:
 ## Dependencies
 
 This layer depends on:
+
+```
+URI: https://git.toradex.com/meta-toradex-bsp-common.git
+branch: scarthgap-7.x.y
+revision: HEAD
+```
 
 ```
 URI: https://git.toradex.com/meta-toradex-nxp.git
@@ -27,40 +33,23 @@ revision: HEAD
 
 ## Quick start
 
-The following commands will setup the environment and allow you to build images
-that have Mender integrated.
+See the top level [README](../README.md) for instructions to build using the `kas` tool. Supported configurations are:
 
+- [`verdin-imx8mm.yml`](../kas/verdin-imx8mm.yml)
+- [`verdin-imx8mp.yml`](../kas/verdin-imx8mp.yml)  
+- [`colibri-imx8x.yml`](../kas/colibri-imx8x.yml)
 
-```
-mkdir mender-toradex && cd mender-toradex
+### Example build commands
 
-# Select the appropriate Toradex BSP version:
-export TORADEX_BSP_VERSION=7.1.0
+```bash
+mkdir -p meta-mender-community/mender-toradex && cd meta-mender-community/mender-toradex
 
-repo init -u https://git.toradex.com/toradex-manifest.git \
-    -b refs/tags/${TORADEX_BSP_VERSION} \
-    -m tdxref/default.xml
+# Build for Verdin iMX8M Mini
+kas build ../kas/verdin-imx8mm.yml
 
-wget --directory-prefix .repo/local_manifests \
-    https://raw.githubusercontent.com/mendersoftware/meta-mender-community/kirkstone/scripts/mender-no-setup-layers.xml
+# Build for Verdin iMX8M Plus
+kas build ../kas/verdin-imx8mp.yml
 
-repo sync
-
-. ./export
-
-echo "BBLAYERS += \" \${TOPDIR}/../layers/meta-mender/meta-mender-core \"" >> conf/bblayers.conf
-echo "BBLAYERS += \" \${TOPDIR}/../layers/meta-mender-community/meta-mender-toradex-nxp \"" >> conf/bblayers.conf
-
-# Omit this, if you intend to use this build in production
-echo "BBLAYERS += \" \${TOPDIR}/../layers/meta-mender/meta-mender-demo \"" >> conf/bblayers.conf
-
-cat ../layers/meta-mender-community/templates/local.conf.append >> conf/local.conf
-cat ../layers/meta-mender-community/meta-mender-toradex-nxp/templates/local.conf.append >> conf/local.conf
-
-echo "TORADEX_BSP_VERSION = \"toradex-bsp-${TORADEX_BSP_VERSION}\"" >> conf/local.conf
-
-You need to accept the Freescale EULA at ‘…/sources/meta-freescale/EULA’. Please read it and in case you accept it, run:
-echo "ACCEPT_FSL_EULA = \"1\"" >> conf/local.conf 
-
-MACHINE=blah bitbake tdx-reference-minimal-image
+# Build for Colibri iMX8X
+kas build ../kas/colibri-imx8x.yml
 ```


### PR DESCRIPTION
Add kas build configurations for the three supported Toradex boards:
- Toradex Verdin iMX8M Mini
- Toradex Verdin iMX8M Plus
- Toradex Colibri iMX8X

This replaces the complex repo-based setup with simple kas commands. The configurations properly inherit from the NXP include files and add all Toradex-specific settings including TEZI image support.

Also update the README to follow the canonical format used by other meta-mender sub-layers, removing the outdated repo-based instructions in favor of kas.